### PR TITLE
Fix color range for inactive channels

### DIFF
--- a/documentation/changelog.md
+++ b/documentation/changelog.md
@@ -4,6 +4,7 @@
 
 Changes/New features:
 
+* Fixed inappropriate color range for saving xy scans with several channels in the confocal part
 * Added support for Keysight M8195A and M8190A AWGs.
 * Added functionality to simultaneously record multiple frequency ranges in the ODMR toolchain 
 in case the hardware supports it.

--- a/gui/confocal/confocalgui.py
+++ b/gui/confocal/confocalgui.py
@@ -1641,7 +1641,7 @@ class ConfocalGui(GUIBase):
             high_centile = self._mw.xy_cb_high_percentile_DoubleSpinBox.value()
             pcile_range = [low_centile, high_centile]
 
-        self._scanning_logic.save_xy_data(colorscale_range=cb_range, percentile_range=pcile_range, block=False)
+        self._scanning_logic.save_xy_data(colorscale_range=cb_range, percentile_range=pcile_range, block=False, active_channel=self.xy_channel)
 
         # TODO: find a way to produce raw image in savelogic.  For now it is saved here.
         filepath = self._save_logic.get_path_for_module(module_name='Confocal')

--- a/logic/confocal_logic.py
+++ b/logic/confocal_logic.py
@@ -1243,8 +1243,6 @@ class ConfocalLogic(GenericLogic):
         if cbar_range is None:
             cbar_range = [np.min(data), np.max(data)]
 
-
-
         # Scale color values using SI prefix
         prefix = ['', 'k', 'M', 'G']
         prefix_count = 0


### PR DESCRIPTION
I added active channel value transfer to the save_xy function in order to apply manual color range only to the active channel.

## Motivation and Context
The issue was that you got the wrong color range while saving several channels, especially if they differ in values greatly. I was forcing you to save several times in order to get nice pictures of your scans.

## How Has This Been Tested?
I tested it on a dummy confocal setup, using print(), and changing the manual color range.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have documented my changes in the changelog (`documentation/changelog.md`)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added/updated for the module the config example in the docstring of the class accordingly.
- [x] I have checked that the change does not contain obvious errors (syntax, indentation, mutable default values).
- [ ] I have tested my changes using 'Load all modules' on the default dummy configuration with my changes included.
- [ ] All changed Jupyter notebooks have been stripped of their output cells.
